### PR TITLE
Generalize Drive impls for collection types

### DIFF
--- a/derive-visitor-macros/Cargo.toml
+++ b/derive-visitor-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive-visitor-macros"
 description = "Macros for derive-visitor package"
 categories = ["development-tools"]
-version = "0.1.2"
+version = "0.2.1"
 authors = ["Kit Isaev <14875494+nikis05@users.noreply.github.com>"]
 license = "MIT"
 documentation = "https://docs.rs/derive-visitor"

--- a/derive-visitor/Cargo.toml
+++ b/derive-visitor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "derive-visitor"
 description = "Derive visitor pattern for arbitrary data structures"
 categories = ["development-tools"]
-version = "0.1.2"
+version = "0.2.1"
 authors = ["Kit Isaev <14875494+nikis05@users.noreply.github.com>"]
 license = "MIT"
 edition = "2018"
@@ -13,7 +13,7 @@ keywords = ["visitor", "derive", "macro"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-derive-visitor-macros = { version = "0.1.0", path = "../derive-visitor-macros" }
+derive-visitor-macros = { version = "0.2.1", path = "../derive-visitor-macros" }
 
 [features]
 std-types-drive = []

--- a/derive-visitor/src/lib.rs
+++ b/derive-visitor/src/lib.rs
@@ -89,12 +89,7 @@ pub use derive_visitor_macros::Drive;
 /// See [Visitor].
 pub use derive_visitor_macros::Visitor;
 
-use std::marker::PhantomData;
-use std::{
-    any::Any,
-    cell::Cell,
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-};
+use std::{any::Any, cell::Cell, marker::PhantomData};
 
 #[cfg(feature = "std-types-drive")]
 use std::ops::{Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
@@ -367,34 +362,42 @@ pub trait Drive: Any {
     fn drive<V: Visitor>(&self, visitor: &mut V);
 }
 
-impl<K, Val> Drive for BTreeMap<K, Val>
+// Helper trait to the generic `IntoIterator` Drive impl
+trait DerefAndDrive {
+    fn deref_and_drive<V: Visitor>(self, visitor: &mut V);
+}
+
+// Most collections iterate over item references, this is the trait impl that handles that case
+impl<T: Drive> DerefAndDrive for &T {
+    fn deref_and_drive<V: Visitor>(self, visitor: &mut V) {
+        self.drive(visitor);
+    }
+}
+
+// Map-like collections iterate over item references pairs
+impl<TK: Drive, TV: Drive> DerefAndDrive for (&TK, &TV) {
+    fn deref_and_drive<V: Visitor>(self, visitor: &mut V) {
+        self.0.drive(visitor);
+        self.1.drive(visitor);
+    }
+}
+
+// The following should be able to handle almost all container types:
+// array, BTreeMap, BTreeSet, BinaryHeap, slice, HashMap, HashSet, LinkedList, Vec, VecDeque
+//
+// It even handles Option, since it has a trivial IntoIterator impl.
+impl<T> Drive for T
 where
-    K: Drive,
-    Val: Drive,
+    T: 'static,
+    // HRTB, because this needs to be true for late-bound lifetimes,
+    // as both &self and &visitor have anonymous lifetimes.
+    for<'a> &'a T: IntoIterator,
+    for<'a> <&'a T as IntoIterator>::Item: DerefAndDrive,
 {
     fn drive<V: Visitor>(&self, visitor: &mut V) {
-        for (key, value) in self.iter() {
-            key.drive(visitor);
-            value.drive(visitor);
+        for item in self {
+            item.deref_and_drive(visitor);
         }
-    }
-}
-
-impl<T> Drive for BTreeSet<T>
-where
-    T: Drive,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        self.iter().for_each(|item| item.drive(visitor));
-    }
-}
-
-impl<T> Drive for BinaryHeap<T>
-where
-    T: Drive,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        self.iter().for_each(|item| item.drive(visitor));
     }
 }
 
@@ -406,75 +409,12 @@ where
         (**self).drive(visitor);
     }
 }
-
 impl<T> Drive for Cell<T>
 where
     T: Drive + Copy,
 {
     fn drive<V: Visitor>(&self, visitor: &mut V) {
         self.get().drive(visitor);
-    }
-}
-
-impl<K, Val, S> Drive for HashMap<K, Val, S>
-where
-    K: Drive,
-    Val: Drive,
-    S: 'static,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        for (key, value) in self.iter() {
-            key.drive(visitor);
-            value.drive(visitor);
-        }
-    }
-}
-
-impl<T, S> Drive for HashSet<T, S>
-where
-    T: Drive,
-    S: 'static,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        self.iter().for_each(|item| item.drive(visitor));
-    }
-}
-
-impl<T> Drive for LinkedList<T>
-where
-    T: Drive,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        self.iter().for_each(|item| item.drive(visitor));
-    }
-}
-
-impl<T> Drive for Option<T>
-where
-    T: Drive,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        if let Some(value) = self {
-            value.drive(visitor);
-        }
-    }
-}
-
-impl<T> Drive for Vec<T>
-where
-    T: Drive,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        self.iter().for_each(|item| item.drive(visitor));
-    }
-}
-
-impl<T> Drive for VecDeque<T>
-where
-    T: Drive,
-{
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        self.iter().for_each(|item| item.drive(visitor));
     }
 }
 
@@ -510,41 +450,6 @@ tuple_impls! {
     T0, T1, T2, T3, T4, T5 => 0, 1, 2, 3, 4, 5
     T0, T1, T2, T3, T4, T5, T6 => 0, 1, 2, 3, 4, 5, 6
     T0, T1, T2, T3, T4, T5, T6, T7 => 0, 1, 2, 3, 4, 5, 6, 7
-}
-
-impl<T> Drive for [T; 0]
-where
-    T: Drive,
-{
-    fn drive<V: Visitor>(&self, _visitor: &mut V) {}
-}
-
-macro_rules! array_impls {
-    ( $( $len:expr => $( $field:expr ),+ )+ ) => {
-        $(
-            impl<T> Drive for [T; $len]
-            where
-                T: Drive
-            {
-                fn drive<V: Visitor>(&self, visitor: &mut V) {
-                    $(
-                        self[$field].drive(visitor);
-                    )+
-                }
-            }
-        )+
-    };
-}
-
-array_impls! {
-    1 => 0
-    2 => 0, 1
-    3 => 0, 1, 2
-    4 => 0, 1, 2, 3
-    5 => 0, 1, 2, 3, 4
-    6 => 0, 1, 2, 3, 4, 5
-    7 => 0, 1, 2, 3, 4, 5, 6
-    8 => 0, 1, 2, 3, 4, 5, 6, 7
 }
 
 #[cfg(feature = "std-types-drive")]

--- a/derive-visitor/tests/test_containers.rs
+++ b/derive-visitor/tests/test_containers.rs
@@ -1,0 +1,71 @@
+use std::{
+    cell::Cell,
+    collections::{HashMap, LinkedList},
+};
+
+use derive_visitor::{Drive, Visitor};
+
+#[derive(Default, Drive)]
+struct Top {
+    tuple_field: (CountMe1, CountMe2, CountMe1, CountMe2, CountMe1, CountMe2),
+    array_field: Box<[CountMe1; 5]>,
+    vec_field: Vec<CountMe2>,
+    map_field: HashMap<CountMe1, CountMe2>,
+    option_field: Option<CountMe2>,
+    list_field: LinkedList<CountMe1>,
+    cell_field: Cell<CountMe2>,
+}
+
+#[derive(Default, Drive, PartialEq, Eq, Hash)]
+struct CountMe1;
+#[derive(Default, Drive, Clone, Copy)]
+struct CountMe2;
+
+#[derive(Debug, Default, PartialEq, Eq, Visitor)]
+#[visitor(CountMe1(enter), CountMe2(enter))]
+struct TestVisitor {
+    count1: usize,
+    count2: usize,
+}
+
+impl TestVisitor {
+    fn enter_count_me_1(&mut self, _: &CountMe1) {
+        self.count1 += 1;
+    }
+    fn enter_count_me_2(&mut self, _: &CountMe2) {
+        self.count2 += 1;
+    }
+}
+
+#[test]
+fn test_containers() {
+    let mut top = Top::default();
+    top.vec_field.push(CountMe2);
+    top.vec_field.push(CountMe2);
+    top.map_field.insert(CountMe1, CountMe2);
+    top.list_field.push_back(CountMe1);
+    top.option_field = Some(CountMe2);
+    let mut test_visitor = TestVisitor::default();
+    top.drive(&mut test_visitor);
+
+    // Count1:
+    //   tuple: 3
+    //   array: 5
+    //   map: 1
+    //   list: 1
+    //   SUM: 10
+    // Count2:
+    //   tuple: 3
+    //   vec: 2
+    //   map: 1
+    //   option: 1
+    //   cell: 1
+    //   SUM: 8
+    assert_eq!(
+        test_visitor,
+        TestVisitor {
+            count1: 10,
+            count2: 8
+        }
+    );
+}

--- a/derive-visitor/tests/test_std_types.rs
+++ b/derive-visitor/tests/test_std_types.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "std-types-drive")]
 
+use std::ops::Range;
+
 use derive_visitor::{Drive, Visitor};
 
 #[derive(Default, Drive)]
@@ -14,6 +16,7 @@ struct Top {
 struct Inner {
     start: u32,
     end: u32,
+    rng: Range<u32>,
     inner_s: String,
 }
 
@@ -49,6 +52,7 @@ fn test_std_types() {
         inner: Inner {
             start: 12,
             end: 24,
+            rng: 4..6,
             inner_s: "x".into(),
         },
         s2: "zzz".into(),
@@ -60,9 +64,8 @@ fn test_std_types() {
         test_visitor,
         TestVisitor {
             all_strings: vec!["String1".into(), "x".into(), "zzz".into()],
-            sum_u32: 42,
+            sum_u32: 52,
             enter_leave_check: 0,
         }
     );
 }
-

--- a/derive-visitor/tests/test_std_types.rs
+++ b/derive-visitor/tests/test_std_types.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "std-types-drive")]
+
+use derive_visitor::{Drive, Visitor};
+
+#[derive(Default, Drive)]
+struct Top {
+    s: String,
+    inner: Inner,
+    s2: String,
+    vec_field: Vec<u32>,
+}
+
+#[derive(Default, Drive)]
+struct Inner {
+    start: u32,
+    end: u32,
+    inner_s: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Visitor)]
+#[visitor(String, u32)]
+struct TestVisitor {
+    all_strings: Vec<String>,
+    sum_u32: u32,
+    enter_leave_check: u32,
+}
+
+impl TestVisitor {
+    fn enter_string(&mut self, s: &str) {
+        self.all_strings.push(s.to_owned());
+    }
+    fn exit_string(&mut self, s: &str) {
+        assert_eq!(self.all_strings.last().unwrap(), s);
+    }
+    fn enter_u_32(&mut self, n: &u32) {
+        self.sum_u32 += n;
+        self.enter_leave_check += n;
+    }
+    fn exit_u_32(&mut self, n: &u32) {
+        self.enter_leave_check -= n;
+        assert_eq!(self.enter_leave_check, 0);
+    }
+}
+
+#[test]
+fn test_std_types() {
+    let top = Top {
+        s: "String1".into(),
+        inner: Inner {
+            start: 12,
+            end: 24,
+            inner_s: "x".into(),
+        },
+        s2: "zzz".into(),
+        vec_field: vec![1, 2, 3],
+    };
+    let mut test_visitor = TestVisitor::default();
+    top.drive(&mut test_visitor);
+    assert_eq!(
+        test_visitor,
+        TestVisitor {
+            all_strings: vec!["String1".into(), "x".into(), "zzz".into()],
+            sum_u32: 42,
+            enter_leave_check: 0,
+        }
+    );
+}
+


### PR DESCRIPTION
With this rewrite, basically all collection types are automatically supported without the need to write code manually.

Unfortunately this is a breaking change, because it is a conflicting trait impl if someone has already made a custom impl for their collection class with iterates over references of Drive-able items.